### PR TITLE
T8727 - Erro ao Gerar Fatura/Invoice de Clientes Internacionais com a moeda CHF

### DIFF
--- a/num2words/lang_EN.py
+++ b/num2words/lang_EN.py
@@ -21,6 +21,14 @@ from . import lang_EU
 
 
 class Num2Word_EN(lang_EU.Num2Word_EU):
+
+    CURRENCY_FORMS = {
+        "BRL": (('real', 'reais'), ('cent', 'cents')),
+        "USD": (("dollar", "dollars"), ("cent", "cents")),
+        "EUR": (("euro", "euros"), ("cent", "cents")),
+        "CHF": (("swiss franc", "swiss francs"), ("cent", "cents")),
+    }
+
     def set_high_numwords(self, high):
         max = 3 + 3 * len(high)
         for word, n in zip(high, range(max, 3, -3)):

--- a/num2words/lang_PT_BR.py
+++ b/num2words/lang_PT_BR.py
@@ -27,6 +27,7 @@ class Num2Word_PT_BR(lang_PT.Num2Word_PT):
         "BRL": (('real', 'reais'), ('centavo', 'centavos')),
         "USD": (("dolar", "dolares"), ("centavo", "centavos")),
         "EUR": (("euro", "euros"), ("centavo", "centavos")),
+        "CHF": (("franco suíço", "franco-suíços"), ("centavo", "centavos")),
     }
 
     def set_high_numwords(self, high):


### PR DESCRIPTION
# Descrição

- Adiciona tradução de Franco-suiço (CHF) para impressao multi-idioma

# Informações adicionais

- [T8727](https://multi.multidados.tech/web?#id=9136&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)